### PR TITLE
feat(auth): aplica middleware verificarToken nas rotas de escrita, re…

### DIFF
--- a/controllers/atletaController.js
+++ b/controllers/atletaController.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Atleta = require('../models/atletasModel'); 
 
 async function criar(req,res) { 
+    
     try {
     const novoAtleta = await Atleta.create(
         {

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -12,7 +12,7 @@ async function criarLogin(req,res) {
 }; 
 
 async function login(req,res) { 
-    const {email,senha} = req.body; 
+    const {email,senha,funcao} = req.body; 
 
     const usuario = await Registro.findOne({email:email}); 
     if(!usuario) {
@@ -28,17 +28,20 @@ async function login(req,res) {
         id: usuario._id, 
         nome: usuario.nome, 
         email: usuario.email,
+        funcao: usuario.funcao,
     }; 
 
     const token = authMiddleware.gerarToken(payload);
 
-    console.log('Token:', token)
 
     return res.status(201).json({token: `${token}`})
 
 }
 
-module.exports = { criarLogin,login }; 
+async function remover(req,res) { 
+    const {id} = req.params
+    const usuarioRemovido = await Registro.findOneAndDelete({_id:id})
+    return res.status(204).end()
+}
 
-
-
+module.exports = { criarLogin,login,remover}; 

--- a/controllers/treinoController.js
+++ b/controllers/treinoController.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Treino = require('../models/treinosModel'); 
 
 async function criar(req,res) { 
+
     try {
     const novoTreino = await Treino.create(
         {

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -31,11 +31,19 @@ function gerarToken(payload) {
 
 function renovarToken(req,res) { 
     try { 
-        const payload = req.payload ; 
+        console.log("PAYLOAD RECEBIDO AQUI", req.payload);
+        const payload = 
+        {
+            nome: req.payload.nome, 
+            email: req.payload.email, 
+            funcao: req.payload.funcao
+        } ; 
         const novoToken = gerarToken(payload); 
-        res.json({token: `${novoToken}`}) 
+        console.log("PASSOU AQUIIIIIII ")
+        return res.status(200).json({token: `${novoToken}`}) 
     } catch (err) { 
-        res.status(500).json({msg: "Erro ao renovar o token"})
+        console.log("PAYLOAD RECEBIDO AQUI", req.payload, err.message);
+        return res.status(500).json({msg: "Erro ao renovar o token"})
     }
 }; 
 

--- a/middlewares/roleMiddleware.js
+++ b/middlewares/roleMiddleware.js
@@ -1,0 +1,12 @@
+function autorizarFuncoes(...funcoespermitidas) {
+    return (req,res,next) => { 
+        const {funcao} = req.payload ; 
+
+        if(!funcoespermitidas.includes(funcao)) {
+            return res.status(403).json({msg: "Acesso negado, função sem permissão."})
+        }
+        next(); 
+    }
+}
+
+module.exports = {autorizarFuncoes};

--- a/models/loginModel.js
+++ b/models/loginModel.js
@@ -25,6 +25,13 @@ const loginSchema = new mongoose.Schema({
     senha : { 
         type: "String", 
         required: [true,'A senha é obrigatória']
+    }, 
+
+    funcao : { 
+        type: String, 
+        enum: [ 'admin', 'professor', 'aluno' ], 
+        required : [true, 'É obrigatório passar a função.'], 
+        default: 'aluno',
     }
 }, { 
     timestamps: true
@@ -44,6 +51,3 @@ loginSchema.pre('save', async function(next) {
 
 
 module.exports = mongoose.model('Registro', loginSchema); 
-
-
-

--- a/routes/atletaRouter.js
+++ b/routes/atletaRouter.js
@@ -2,19 +2,15 @@ const express = require('express');
 const router = express.Router(); 
 
 const atletasController = require('../controllers/atletaController'); 
+const {verificarToken} = require('../middlewares/authMiddleware'); 
+const {autorizarFuncoes} = require('../middlewares/roleMiddleware'); 
 
-router.post('/', atletasController.criar); 
+router.post('/', verificarToken, autorizarFuncoes('admin'), atletasController.criar); 
 
-router.get('/', atletasController.listar); 
+router.get('/', verificarToken,  atletasController.listar); 
+router.get('/:id', verificarToken, atletasController.buscar, atletasController.exibir); 
 
-router.get('/:id', atletasController.buscar, atletasController.exibir); 
-
-router.put('/:id', atletasController.buscar, atletasController.atualizar); 
-
-router.delete('/:id', atletasController.buscar, atletasController.remover); 
-
-
-
-
+router.put('/:id', verificarToken, autorizarFuncoes('professor', 'admin', 'aluno') ,atletasController.buscar, atletasController.atualizar); 
+router.delete('/:id', verificarToken, autorizarFuncoes('admin'), atletasController.buscar, atletasController.remover); 
 
 module.exports = router; 

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -1,10 +1,15 @@
 const express = require('express'); 
 const router = express.Router(); 
 const AuthController = require('../controllers/authController');
+const { verificarToken, renovarToken } = require('../middlewares/authMiddleware');
+const { autorizarFuncoes } = require('../middlewares/roleMiddleware');
 
-router.post('/criarlogin', AuthController.criarLogin)
-
+router.post('/criarlogin', AuthController.criarLogin);
 router.post('/login', AuthController.login); 
+router.post('/renovar',  verificarToken, renovarToken);
+
+router.delete('/:id', verificarToken, autorizarFuncoes('admin'), AuthController.remover); 
+
 
 
 module.exports = router; 

--- a/routes/treinoRouter.js
+++ b/routes/treinoRouter.js
@@ -2,15 +2,17 @@ const express = require('express');
 const router = express.Router(); 
 
 const treinoController = require('../controllers/treinoController'); 
+const {verificarToken} = require('../middlewares/authMiddleware'); 
+const {autorizarFuncoes} = require('../middlewares/roleMiddleware'); 
 
-router.post('/', treinoController.criar); 
+router.post('/', verificarToken, autorizarFuncoes('professor', 'admin'), treinoController.criar); 
 
-router.get('/', treinoController.listar); 
+router.get('/', verificarToken, treinoController.listar); 
 
-router.get('/:id', treinoController.buscar, treinoController.exibir); 
+router.get('/:id' ,verificarToken, treinoController.buscar, treinoController.exibir); 
 
-router.put('/:id', treinoController.buscar, treinoController.atualizar); 
+router.put('/:id', verificarToken, autorizarFuncoes('professor','admin'), treinoController.buscar, treinoController.atualizar); 
 
-router.delete('/:id', treinoController.buscar, treinoController.remover); 
+router.delete('/:id', verificarToken, autorizarFuncoes('professor', 'admin') ,treinoController.buscar, treinoController.remover); 
 
 module.exports = router; 

--- a/tests/authRouter.test.js
+++ b/tests/authRouter.test.js
@@ -4,37 +4,143 @@ const request = supertest(app);
 
 const urlCriarLogin = ('/auth/criarLogin'); 
 const urlLogin = ('/auth/login'); 
-let id = null; 
-let email = ""; 
-let senha = ""; 
+const urlAuth = '/auth';
+const urlRenovar = '/auth/renovar'
+
+let idAdmin = null; 
+let idAluno = null; 
+let idProfessor = null;
+let emailAdmin = ""; 
+let senhaAdmin = "";
+let tokenAdmin = ""; 
+let novoToken = ""; 
+let emailAluno = ""; 
+let senhaAluno = ""; 
+let emailProfessor = ""; 
+let senhaProfessor = "";  
 
 describe('TESTES DO FLUXO AUTENTICAÇÃO /auth', () => {
 
-    test('POST /auth/criarlogin deve retornar 201', async() => { 
+    test('POST /auth/criarlogin deve retornar 201 (ADMIN)', async() => { 
         const response = await request.post(urlCriarLogin).send({
-            nome: "José da Silva", 
+            nome: "José da Silva TESTE", 
             email: "josedasilva@mail.com.br", 
             motivo: "Trabalho da faculdade", 
             senha: "jose123",
+            funcao: 'admin',
     }); 
         expect(response.status).toBe(201); 
         expect(response.headers['content-type']).toMatch(/json/); 
-        expect(response.body.nome).toBe("José da Silva"); 
+        expect(response.body.nome).toBe("José da Silva TESTE"); 
         expect(response.body.email).toBe("josedasilva@mail.com.br"); 
-        expect(response.body.motivo).toBe("Trabalho da faculdade");
-        
-        id = response.body._id; 
-        email = response.body.email; 
-        senha = "jose123"; 
+        expect(response.body.motivo).toBe("Trabalho da faculdade"); 
+        expect(response.body.funcao).toBe("admin"); 
+        idAdmin = response.body._id; 
+        emailAdmin = response.body.email; 
+        senhaAdmin = "jose123"; 
 });
-    test('POST /auth/login deve retornar 201', async() => { 
+
+    test('POST /auth/criarlogin deve retornar 201 (PROFESSOR)', async() => { 
+        const response = await request.post(urlCriarLogin).send({
+            nome: "Shaolin Matador de Porco TESTE", 
+            email: "shaolinmataporco@mail.com.br", 
+            motivo: "Funcionário", 
+            senha: "shaolin123", 
+            funcao: "professor"
+        }); 
+        expect(response.status).toBe(201); 
+        expect(response.headers['content-type']).toMatch(/json/); 
+        expect(response.body.nome).toBe("Shaolin Matador de Porco TESTE"); 
+        expect(response.body.email).toBe("shaolinmataporco@mail.com.br"); 
+        expect(response.body.funcao).toBe("professor"); 
+        idProfessor = response.body._id; 
+        emailProfessor = response.body.email; 
+        senhaProfessor = "shaolin123"; 
+    }); 
+
+    test('POST /auth/criarlogin deve retornar 201 (ALUNO)', async() => { 
+        const response = await request.post(urlCriarLogin).send({
+            nome: "Paula Vadão TESTE",
+            email: "paulavadao@mail.com.br", 
+            motivo: 'Aluno', 
+            senha: "paula123", 
+            funcao: "aluno"
+        }); 
+        expect(response.status).toBe(201); 
+        expect(response.headers['content-type']).toMatch(/json/); 
+        expect(response.body.nome).toBe("Paula Vadão TESTE"); 
+        expect(response.body.email).toBe("paulavadao@mail.com.br"); 
+        expect(response.body.funcao).toBe("aluno"); 
+        idAluno = response.body._id; 
+        emailAluno = response.body.email; 
+        senhaAluno = "paula123"; 
+    })
+
+    test('POST /auth/login deve retornar 201 (ADMIN)', async() => { 
         const response = await request.post(urlLogin).send({
-            email: email, 
-            senha: senha
+            email: emailAdmin, 
+            senha: senhaAdmin
         });
+        expect(response.status).toBe(201); 
+        expect(response.headers['content-type']).toMatch(/json/); 
+        expect(response.body.token).toBeDefined(); 
+        tokenAdmin = response.body.token; 
+    }); 
+
+    test('POST /auth/login deve retornar 201 (PROFESSOR)', async() => { 
+        const response = await request.post(urlLogin).send({
+            email: emailProfessor, 
+            senha: senhaProfessor
+        }); 
         expect(response.status).toBe(201); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.token).toBeDefined(); 
     }); 
 
+    test('POST /auth/login deve retornar 201 (ALUNO)', async() => { 
+        const response = await request.post(urlLogin).send({
+            email:emailAluno, 
+            senha: senhaAluno
+        });
+        expect(response.status).toBe(201); 
+        expect(response.headers['content-type']).toMatch(/json/); 
+        expect(response.body.token).toBeDefined();
+    });
+
+    test('POST /auth/renovar deve retornar 200', async() => { 
+        const response = await request.post(urlRenovar)
+        .set('Authorization', `Bearer ${tokenAdmin}`); 
+        expect(response.status).toBe(200); 
+        expect(response.headers['content-type']).toMatch(/json/);
+        expect(response.body.token).toBeDefined(); 
+        novoToken = response.body.token ; 
+    }); 
+
+    test('GET /atletas deve retornar 200', async() => { 
+        const response = await request.get('/atletas')
+        .set('Authorization', `Bearer ${novoToken}`); 
+        expect(response.status).toBe(200); 
+        expect(response.headers['content-type']).toMatch(/json/); 
+    })
+
+    test('DELETE /auth deve retornar 204 (ADMIN)', async() => {
+        const response = await request.delete(`${urlAuth}/${idAdmin}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`); 
+        expect(response.status).toBe(204); 
+    }); 
+
+    test('DELETE /auth deve retornar 204 (PROFESSOR)', async() => { 
+        const response = await request.delete(`${urlAuth}/${idProfessor}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`); 
+        expect(response.status).toBe(204);
+    }); 
+
+    test('DELETE /auth deve retornar 204 (ALUNO)', async() => { 
+        const response = await request.delete(`${urlAuth}/${idAluno}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        ; 
+        expect(response.status).toBe(204); 
+    })
+    
+    
 })

--- a/tests/treinoRouter.test.js
+++ b/tests/treinoRouter.test.js
@@ -2,27 +2,90 @@ const supertest = require('supertest');
 const app = require('../app'); 
 const request = supertest(app); 
 
+let tokenProfessor = null; 
+let tokenAluno = null ; 
+let tokenAdmin = null ;
+let adminId = null ; 
+let professorId = null ; 
+let alunoId = null ; 
 let atletaId = null ; 
 let treinoId = null ; 
 const url = '/treinos'; 
 
 beforeAll(async() => { 
-    const res = await request.post('/atletas').send({
-        nome: "Pedro Resende",
-        email: "pedroresendo@mail.com.br", 
-        idade: 29, 
-        peso: 65.2, 
-        altura: 1.71, 
-        modalidade: "Ciclismo", 
-        ativo: true
+
+    const adminCriado = await request.post('/auth/criarlogin').send({
+        nome: "José da Silva", 
+        email: "josedasilva@mail.com.br", 
+        motivo: "Trabalho da faculdade", 
+        senha: "jose123",
+        funcao: 'admin'
     }); 
-    atletaId = res.body._id; 
+
+    const professorCriado = await request.post('/auth/criarlogin').send({
+        nome: "Shaolin Matador de Porco", 
+        email: "shaolinmataporco@mail.com.br", 
+        motivo: "Funcionário", 
+        senha: "shaolin123", 
+        funcao: "professor"
+    }); 
+
+    const alunoCriado = await request.post('/auth/criarlogin').send({
+        nome: "Paula Vadão",
+        email: "paulavadao@mail.com.br", 
+        motivo: 'Aluno', 
+        senha: "paula123", 
+        funcao: "aluno"
+    }); 
+
+    adminId = adminCriado.body._id; 
+    professorId = professorCriado.body._id; 
+    alunoId = alunoCriado.body._id; 
+
+
+    const resAdmin = await request.post('/auth/login').send({
+        email: adminCriado.body.email, 
+        senha: "jose123"
+    }); 
+    tokenAdmin = resAdmin.body.token; 
+
+    const resProfessor = await request.post('/auth/login').send({
+        email: professorCriado.body.email, 
+        senha: "shaolin123" 
+    }); 
+    tokenProfessor = resProfessor.body.token; 
+
+    const resAluno = await request.post('/auth/login').send({
+        email: alunoCriado.body.email, 
+        senha: "paula123"
+    }); 
+
+    tokenAluno = resAluno.body.token; 
+
+    const resAtleta = await request
+    .post('/atletas')
+    .set('Authorization', `Bearer ${tokenAdmin}`)
+    .send(
+        {
+            nome: "Pedro Resende", 
+            email: "pedroresende@mail.com.br", 
+            idade: 30,
+            peso: 66, 
+            altura: 170, 
+            modalidade: 'Ciclismo', 
+            ativo: true
+        }
+    ); 
+    atletaId = resAtleta.body._id; 
+
 }); 
 
 describe('Testes do recurso /treinos', () => { 
     
     test('POST /treinos deve retornar 201', async() => { 
-        const response = await request.post(url).send({
+        const response = await request.post(url)
+        .set('Authorization', `Bearer ${tokenProfessor}`)
+        .send({
             atleta: atletaId, 
             data: "2025-10-25", 
             tipo: 'Ciclismo', 
@@ -44,8 +107,19 @@ describe('Testes do recurso /treinos', () => {
         treinoId = response.body._id ; 
     }); 
 
+    test('POST /atletas deve retornar 403', async() => { 
+        const response = await request
+        .post(url)
+        .set('Authorization', `Bearer ${tokenAluno}`); 
+
+        expect(response.status).toBe(403); 
+        expect(response.body.msg).toBe("Acesso negado, função sem permissão.")
+    }); 
+
     test('POST /treinos deve retornar 422(Criar sem passar o body)', async() => { 
-        const response = await request.post(url); 
+        const response = await request
+        .post(url)
+        .set('Authorization', `Bearer ${tokenProfessor}`) 
         expect(response.headers['content-type']).toMatch(/json/);
         expect(response.status).toBe(422); 
         expect(response.body.msg).toBe("Obrigatório passar o corpo da requisição");
@@ -53,14 +127,18 @@ describe('Testes do recurso /treinos', () => {
 
 
     test('GET /treinos deve retornar 200', async() => { 
-        const response = await request.get(url); 
+        const response = await request
+        .get(url)
+        .set('Authorization', `Bearer ${tokenAluno}`);  
         expect(response.status).toBe(200); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(Array.isArray(response.body)).toBe(true); 
     }); 
 
     test('GET /treinos/:id deve retornar 200', async() => { 
-        const response = await request.get(`${url}/${treinoId}`); 
+        const response = await request
+        .get(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenAluno}`)
         expect(response.status).toBe(200); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body._id).toBeDefined(); 
@@ -74,14 +152,17 @@ describe('Testes do recurso /treinos', () => {
     }); 
 
     test('GET /treinos/0 deve retornar 400 (Buscar um objeto com um ID inválido', async() => {
-        const response = await request.get(`${url}/0`); 
+        const response = await request.get(`${url}/0`)
+        .set('Authorization', `Bearer ${tokenAluno}`); 
         expect(response.status).toBe(400); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.msg).toBe("Parâmetro inválido")
     }); 
 
     test('GET /treinos/000000000000000000000000 deve retornar 404 (Válido mas não existente)', async() => { 
-        const response = await request.get(`${url}/000000000000000000000000`); 
+        const response = await request
+        .get(`${url}/000000000000000000000000`)
+        .set('Authorization', `Bearer ${tokenAluno}`);  
         expect(response.status).toBe(404); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.msg).toBe("Treino não encontrado"); 
@@ -89,7 +170,9 @@ describe('Testes do recurso /treinos', () => {
 
 
     test('PUT /treinos/:id deve retornar 200', async() => { 
-        const response = await request.put(`${url}/${treinoId}`)
+        const response = await request
+        .put(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`)
         .send(
             {
                 atleta: atletaId,
@@ -114,21 +197,36 @@ describe('Testes do recurso /treinos', () => {
     }); 
 
     test('PUT /treinos/0 deve retornar 400 (ID inválido)', async() => { 
-        const response = await request.put(`${url}/0`); 
+        const response = await request
+        .put(`${url}/0`)
+        .set('Authorization', `Bearer ${tokenAdmin}`); 
         expect(response.status).toBe(400); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.msg).toBe("Parâmetro inválido")
     }); 
 
+    test('PUT /atletas deve retornar 403', async() => { 
+        const response = await request
+        .put(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenAluno}`); 
+
+        expect(response.status).toBe(403); 
+        expect(response.body.msg).toBe("Acesso negado, função sem permissão.")
+    }); 
+
     test('PUT /treinos/000000000000000000000000 deve retornar 404 (Válido mas não existente)', async() => { 
-        const response = await request.put(`${url}/000000000000000000000000`); 
+        const response = await request
+        .put(`${url}/000000000000000000000000`)
+        .set('Authorization', `Bearer ${tokenAdmin}`); 
         expect(response.status).toBe(404); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.msg).toBe("Treino não encontrado"); 
     }); 
 
     test('PUT /treinos/:id deve retornar 422(Sem passar os parâmetros obrigatórios)', async() => { 
-        const response = await request.put(`${url}/${treinoId}`)
+        const response = await request
+        .put(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`)
         .send({
             atleta: "", 
             data: "", 
@@ -142,19 +240,32 @@ describe('Testes do recurso /treinos', () => {
     })
 
     test('DELETE /treinos/:id deve retornar 204 sem corpo', async() => { 
-        const response = await request.delete(`${url}/${treinoId}`); 
+        const response = await request.delete(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenProfessor}`) 
         expect(response.status).toBe(204); 
     }); 
 
     test('DELETE /treinos/0 deve retornar 400', async() => { 
-        const response = await request.delete(`${url}/0`); 
+        const response = await request
+        .delete(`${url}/0`)
+        .set('Authorization', `Bearer ${tokenProfessor}`); 
         expect(response.status).toBe(400); 
         expect(response.headers['content-type']).toMatch(/json/); 
         expect(response.body.msg).toBe("Parâmetro inválido")
     }); 
 
+    test('PUT /atletas deve retornar 403', async() => { 
+        const response = await request
+        .delete(`${url}/${treinoId}`)
+        .set('Authorization', `Bearer ${tokenAluno}`); 
+
+        expect(response.status).toBe(403); 
+        expect(response.body.msg).toBe("Acesso negado, função sem permissão.")
+    }); 
+
     test('DELETE /treinos/000000000000000000000000 deve retornar 404 (Válido mas não existente)', async() => { 
-    const response = await request.delete(`${url}/000000000000000000000000`); 
+    const response = await request.delete(`${url}/000000000000000000000000`)
+    .set('Authorization', `Bearer ${tokenProfessor}`); 
     expect(response.status).toBe(404); 
     expect(response.headers['content-type']).toMatch(/json/); 
     expect(response.body.msg).toBe("Treino não encontrado"); 
@@ -166,8 +277,21 @@ describe('Testes do recurso /treinos', () => {
 afterAll(async() => { 
     if(atletaId) { 
         await request.delete(`/atletas/${atletaId}`)
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+    }; 
+    const usuariosRemovidos = [ 
+        {id:adminId, token: tokenAdmin}, 
+        {id:professorId, token: tokenAdmin},
+        {id:alunoId, token: tokenAdmin},
+    ]; 
+
+    for (const usuario of usuariosRemovidos) { 
+        if(usuario.id){
+            await request
+            .delete(`/auth/${usuario.id}`)
+            .set('Authorization', `Bearer ${tokenAdmin}`)
+        }; 
     }
 }); 
-
 
 


### PR DESCRIPTION
### ✨ Objetivo
Esta PR implementa o requisito de segurança obrigatório para **proteger as rotas que modificam dados** (POST, PUT, DELETE).

Resolve a **Issue #9: Implementar Middleware de Autenticação JWT**.

### 🛠️ O que foi feito
1.  **Middleware Aplicado:** O `authMiddleware.verificarToken` foi adicionado como *middleware* nas rotas de escrita.
2.  **Rotas Protegidas:**
    * `/atletas` (POST, PUT, DELETE)
    * `/treinos` (POST, PUT, DELETE)

### 🚨 Como Testar
Para validar esta funcionalidade, o usuário deve:

1.  Tentar acessar uma rota de escrita (ex: `POST /atletas`) **sem fornecer o cabeçalho `Authorization`**.
    * **Resultado Esperado:** A API deve retornar o status **401 (Unauthorized)**.

2.  Tentar acessar com um token JWT **inválido ou expirado**.
    * **Resultado Esperado:** A API deve retornar o status **401 (Unauthorized)** e uma mensagem de erro apropriada.

### Próximos Passos
Após o merge desta PR, a **Issue #10 (Testes de Segurança)** será o foco para garantir que a proteção seja mantida contra regressões.